### PR TITLE
example用Dockerイメージ差し替え

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,11 @@ on:
       - '**'
 
 env:
-  IMAGE_NAME: ssh-separator
+  APP_IMAGE_NAME: ssh-separator
+  USER_IMAGE_NAME: ssh-separator-ubuntu
 
 jobs:
-  image:
+  app_image:
     name: Build Docker Image
     runs-on: ubuntu-latest
     env:
@@ -41,9 +42,11 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
-            ghcr.io/mazrean/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/mazrean/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ghcr.io/mazrean/${{ env.APP_IMAGE_NAME }}:latest
+            ghcr.io/mazrean/${{ env.APP_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
   cli:
     runs-on: ubuntu-latest
     steps:
@@ -62,3 +65,38 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  user_image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Set IMAGE_TAG env
+        run: echo "IMAGE_TAG=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Show available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: mazrean
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/mazrean/${{ env.USER_IMAGE_NAME }}:latest
+            ghcr.io/mazrean/${{ env.USER_IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [OpenAPI](https://mazrean.github.io/ssh-separator/openapi/) for details.
 ## Environment Variables
 |variable|description|example value|
 |-|-|-|
-|WELCOME|The string displayed upon successful login.|Login succeeded!|
+|WELCOME|The string displayed upon successful login.|Login success!|
 |API_KEY|API key for REST API.|aeneexiene7uu3fie4pa|
 |API_PORT|Port for REST API|3000|
 |SSH_PORT|Port for ssh|2222|

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -6,19 +6,12 @@ services:
       context: ..
       dockerfile: dev/Dockerfile
     environment:
-      WELCOME: "
-        \n ██████╗██████╗  ██████╗████████╗███████╗
-        \n██╔════╝██╔══██╗██╔════╝╚══██╔══╝██╔════╝
-        \n██║     ██████╔╝██║        ██║   █████╗  
-        \n██║     ██╔═══╝ ██║        ██║   ██╔══╝  
-        \n╚██████╗██║     ╚██████╗   ██║   ██║     
-        \n ╚═════╝╚═╝      ╚═════╝   ╚═╝   ╚═╝     
-        \n\n"
+      WELCOME: "Login success!"
       PROMETHEUS: "true"
       API_PORT: 3000
       SSH_PORT: 2222
       BADGER_DIR: /tmp/badger
-      IMAGE_NAME: mazrean/cpctf-ubuntu:latest
+      IMAGE_NAME: ghcr.io/mazrean/ssh-separator-ubuntu:latest
       IMAGE_USER: ubuntu
       IMAGE_CMD: /bin/bash
       CPU_LIMIT: 0.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       API_PORT: 3000
       SSH_PORT: 2222
       BADGER_DIR: /tmp/badger
-      IMAGE_NAME: mazrean/cpctf-ubuntu:latest
+      IMAGE_NAME: ghcr.io/mazrean/ssh-separator-ubuntu:latest
       IMAGE_USER: ubuntu
       IMAGE_CMD: /bin/bash
       API_KEY: api_key # key for the REST API. you need to rewrite this in production.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,59 +1,6 @@
-# syntax = docker/dockerfile:1.0-experimental
+# syntax = docker/dockerfile:1.3.0
 
-FROM ubuntu:20.04
-
-RUN \
-  --mount=type=cache,target=/var/cache/apt \
-  --mount=type=cache,target=/var/lib/apt \
-  apt update && \
-  apt install -y tzdata && \
-  apt install -y --fix-missing \
-  curl \
-  wget \
-  netcat \
-  git \
-  python3 \
-  python3-pip \
-  sudo \
-  libtiff5-dev \
-  libjpeg8-dev \
-  libopenjp2-7-dev \
-  zlib1g-dev \
-  libfreetype6-dev \
-  liblcms2-dev \
-  libwebp-dev \
-  tcl8.6-dev \
-  tk8.6-dev \
-  python-tk \
-  libharfbuzz-dev \
-  libfribidi-dev \
-  libssl-dev \
-  zlib1g-dev \
-  libbz2-dev \
-  libreadline-dev \
-  libsqlite3-dev \
-  llvm \
-  libncurses5-dev \
-  xz-utils \
-  tk-dev \
-  libxml2-dev \
-  libxmlsec1-dev \
-  libffi-dev \
-  liblzma-dev \
-  gcc \
-  make \
-  build-essential \
-  binutils \
-  vim \
-  emacs
-
-RUN pip3 install flask
-
-RUN wget https://github.com/longld/peda/archive/refs/tags/v1.2.tar.gz && \
-  mkdir ~/peda && \
-  tar xvzf v1.2.tar.gz -C ~/peda && \
-  rm v1.2.tar.gz
-RUN echo "source ~/peda/peda.py" >> ~/.gdbinit
+FROM ubuntu:21.04
 
 RUN useradd -m --uid 1000 --groups sudo ubuntu && \
   echo 'ubuntu:ubuntu' | chpasswd


### PR DESCRIPTION
exampleのCPCTF用のdockerイメージをexample用に作ったdockerイメージに差し替えた。
ついでにGitHub Actionsのイメージのbuildでキャッシュが効くようにしている。