### PR TITLE
GitHub Actionのjobの名前修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   app_image:
-    name: Build Docker Image
+    name: Build App Image
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   user_image:
-    name: Build Docker Image
+    name: Build User Image
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1


### PR DESCRIPTION
アプリケーション用イメージとユーザー用イメージのbuildのjob名が同じで紛らわしかったので修正した。