### PR TITLE
CIなどのGoのバージョン更新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mazrean/separated-webshell
 
-go 1.17
+go 1.
 
 require (
 	github.com/dgraph-io/badger/v3 v3.2103.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mazrean/separated-webshell
 
-go 1.
+go 1.20
 
 require (
 	github.com/dgraph-io/badger/v3 v3.2103.5


### PR DESCRIPTION
CIなどでgo.modでGoのバージョンを決めていたにも関わらず、go.modのばーじょんを上げ忘れていたので対応した。