### PR TITLE
Ubuntu 23.04に対応

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,4 @@
 
 FROM ubuntu:23.04
 
-RUN useradd -m --uid 1000 --groups sudo ubuntu && \
-  echo 'ubuntu:ubuntu' | chpasswd
 RUN echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Ubuntu 23.04から初期状態でubuntuユーザーが作られるようになり、リリースに失敗していたので修正した。